### PR TITLE
Feat/aaic 584 reset chat

### DIFF
--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -507,6 +507,9 @@ class Widget extends Component {
 
     if (isChatOpen) {
       this.removeHistory();
+      this.createNewSession();
+    } else {
+      this.resendInitPayload();
     }
 
     if (isChatOpen && this.delayedMessage) {
@@ -534,14 +537,24 @@ class Widget extends Component {
 
   removeHistory() {
     // removes session data and messages from the session or local storage
-    const {storage, dispatch, socket } = this.props;
+    const {storage, dispatch } = this.props;
     storage.removeItem(SESSION_NAME);
 
     // removes
     dispatch(dropMessages());
     dispatch(resetSessionId());
+  }
 
+  createNewSession() {
+    const { socket } = this.props;
     socket.emit('session_request');
+  }
+
+  resendInitPayload() {
+    const { socket, customData, initPayload } = this.props;
+    const sessionId = this.getSessionId();
+
+    socket.emit('user_uttered', { message: initPayload, customData, session_id: sessionId });
   }
 
   toggleFullScreen() {

--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -31,7 +31,9 @@ import {
   changeOldUrl,
   setDomHighlight,
   evalUrl,
-  setCustomCss
+  setCustomCss,
+  dropMessages,
+  resetSessionId
 } from 'actions';
 import { safeQuerySelectorAll } from 'utils/dom';
 import { SESSION_NAME, NEXT_MESSAGE } from 'constants';
@@ -502,7 +504,13 @@ class Widget extends Component {
       dispatch,
       disableTooltips
     } = this.props;
+
+    if (isChatOpen) {
+      this.removeHistory();
+    }
+
     if (isChatOpen && this.delayedMessage) {
+
       if (!disableTooltips) dispatch(showTooltip(true));
       clearTimeout(this.messageDelayTimeout);
       this.dispatchMessage(this.delayedMessage);
@@ -522,6 +530,18 @@ class Widget extends Component {
     }
     clearTimeout(this.tooltipTimeout);
     dispatch(toggleChat());
+  }
+
+  removeHistory() {
+    // removes session data and messages from the session or local storage
+    const {storage, dispatch, socket } = this.props;
+    storage.removeItem(SESSION_NAME);
+
+    // removes
+    dispatch(dropMessages());
+    dispatch(resetSessionId());
+
+    socket.emit('session_request');
   }
 
   toggleFullScreen() {

--- a/src/store/actions/actionTypes.js
+++ b/src/store/actions/actionTypes.js
@@ -36,4 +36,5 @@ export const SET_HINT_TEXT = 'SET_HINT_TEXT';
 export const SET_OLD_URL = 'SET_OLD_URL';
 export const EVAL_URL = 'EVAL_URL';
 export const SET_CUSTOM_CSS = 'SET_CUSTOM_CSS';
+export const RESET_SESSION_ID = 'RESET_SESSION_ID';
 

--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -253,3 +253,10 @@ export function setCustomCss(customCss) {
   };
 }
 
+
+export function resetSessionId() {
+  return {
+    type: actions.RESET_SESSION_ID
+  };
+}
+

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -60,6 +60,10 @@ function initStore(
       }
     };
     switch (action.type) {
+      case actionTypes.RESET_SESSION_ID: {
+        sessionId = null;
+        break;
+      }
       case actionTypes.EMIT_NEW_USER_MESSAGE: {
         emitMessage(action.text);
         break;


### PR DESCRIPTION
Reset the sessionId and remove information from the client upon closing the chat widget.
Start a new conversation, when opening the chat widget again.